### PR TITLE
Treat None as missing in config when updating

### DIFF
--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -91,6 +91,8 @@ def update(old, new, priority='new'):
             old[k] = {}
 
         if type(v) is dict:
+            if old[k] is None:
+                old[k] = {}
             update(old[k], v, priority=priority)
         else:
             if priority == 'new' or k not in old:

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -356,7 +356,7 @@ def test_normalize_nested_keys():
 
 def test_env_var_normalization(monkeypatch):
     value = 3
-    monkeypatch.setenv('TEST_A_B', value)
+    monkeypatch.setenv('TEST_A_B', str(value))
     config = Config(config_name)
 
     assert config.get('a_b') == value

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -372,6 +372,10 @@ def test_get_set_roundtrip(key):
         assert config.get('custom-key') == value
 
 
+def test_merge_None_to_dict():
+    assert merge({'a': None, 'c': 0}, {'a': {'b': 1}}) == {'a': {'b': 1}, 'c': 0}
+
+
 if __name__ == '__main__':
     import sys
     import pytest


### PR DESCRIPTION
This is a migration of https://github.com/dask/dask/pull/4324 from dask to donfig.

> Sometimes users provide None/null in configuration to indicate that they
don't have a value.
>
> Previously this would break when we went to merge configurations.
>
> Now we accept merging a dict into None, replacing the None value rather than
erring.