### PR TITLE
Fix environment variable loading only working with 4 characters

### DIFF
--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018 Donfig Developers
+# Copyright (c) 2018-2019 Donfig Developers
 # Copyright (c) 2014-2018, Anaconda, Inc. and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -199,9 +199,10 @@ def collect_env(prefix, env=None):
     if env is None:
         env = os.environ
     d = {}
+    prefix_len = len(prefix)
     for name, value in env.items():
         if name.startswith(prefix):
-            varname = name[5:].lower().replace('__', '.')
+            varname = name[prefix_len:].lower().replace('__', '.')
             try:
                 d[varname] = ast.literal_eval(value)
             except (SyntaxError, ValueError):


### PR DESCRIPTION
There was a hardcoded `[5:]` indexing done on environment variable names that works for any package name that is 4 letters long (ex. `DASK`). If the package name was longer than that then donfig wouldn't find the environment variable or rather it would assign the wrong value by not cutting enough of the prefix away.

This issue wasn't caught before because all my tests used a test config name of "test" (4 characters).