### PR TITLE
Silence deprecation warning for collections.Mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ env:
   - CONDA_CHANNELS='conda-forge'
 matrix:
   include:
-  - env: PYTHON_VERSION=2.7
-    os: linux
-  - env: PYTHON_VERSION=2.7
-    os: osx
   - env: PYTHON_VERSION=3.6
     os: linux
   - env: PYTHON_VERSION=3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,6 @@ environment:
     CONDA_CHANNELS: "conda-forge"
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"

--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -27,7 +27,7 @@ import sys
 import threading
 import pprint
 from copy import deepcopy
-from collections import Mapping
+from collections.abc import Mapping
 
 try:
     from contextlib import nullcontext

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(name=NAME,
       zip_safe=False,
       install_requires=['pyyaml'],
       tests_require=['pytest'],
-      python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+      python_requires='>=3.4,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
       )

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,5 @@ setup(name=NAME,
       zip_safe=False,
       install_requires=['pyyaml'],
       tests_require=['pytest'],
-      python_requires='>=3.4,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+      python_requires='>=3.6',
       )


### PR DESCRIPTION
Starting with Python 3.7 (maybe earlier?) a DeprecationWarning is generated:

> /Users/sseibert/anaconda/envs/mg/lib/python3.7/site-packages/donfig/config_obj.py:30: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
>     from collections import Mapping

To preserve Python 2.7 support, this PR tries first to import from the currently preferred module, then falls back to the old module if that fails.