### PR TITLE
Refactor config default search path retrieval

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -128,11 +128,6 @@ subprojects to manage configuration files separately, but have them merge
 into the same global configuration (ex. ``dask``, ``dask-kubernetes``,
 ``dask-ml``).
 
-.. note::
-
-    For historical reasons we also look in the ``~/.mypkg`` directory for
-    config files.  This is deprecated and will soon be removed.*
-
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -344,7 +344,6 @@ class Config(object):
                 os.path.join(sys.prefix, 'etc', name),
                 *[os.path.join(prefix, "etc", name) for prefix in site.PREFIXES],
                 os.path.join(os.path.expanduser('~'), '.config', name),
-                os.path.join(os.path.expanduser('~'), '.{}'.format(name))
             ]
 
         if env_prefix is None:


### PR DESCRIPTION
Port of https://github.com/dask/dask/pull/8573 to donfig.

Authored by @jrbourbeau in the original dask PR. This removes a long deprecated path from the search list. A lot of the additional refactoring done by James in his PR is not needed here as donfig is already required to use a separate Config object for each new instance. So for this PR's tests the `Config.paths` property is considered public while it may not be considered that in dask. Lastly, I did not include James' last test:

```python
def test_default_search_paths():
    # Ensure _get_paths() is used for default paths
    assert dask.config.paths == _get_paths()
```

as I'm not sure how I would structure donfig to do this. I could extract the path logic to another function, but it would depend on name of the config and the environment variable. At this time this logic is a little too interconnected. For now I'm leaving it.