### PR TITLE
Make `test__get_paths` robust to `site.PREFIXES` being set

### DIFF
--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -498,11 +498,12 @@ def test_path_includes_site_prefix():
 
 
 def test__get_paths(monkeypatch):
-    # These environment variables, if present, would interfere with these tests
+    # These settings, if present, would interfere with these tests
     # We temporarily remove them to avoid interference from the
     # machine where tests are being run.
     monkeypatch.delenv("MYPKG_CONFIG", raising=False)
     monkeypatch.delenv("MYPKG_ROOT_CONFIG", raising=False)
+    monkeypatch.setattr(site, "PREFIXES", [])
 
     expected = [
         "/etc/mypkg",


### PR DESCRIPTION
Port of https://github.com/dask/dask/pull/8644