### PR TITLE
Add SerializableLock from Dask to use in `Config.set`

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - pytest
   - pytest-cov
   - python=3.9
+  - cloudpickle

--- a/donfig/_lock.py
+++ b/donfig/_lock.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Donfig Developers
+# Copyright (c) 2014-2022, Anaconda, Inc. and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Config syncronization locks ported from upstream dask.
+
+Originally part of Dask and stored in the dask/utils.py module. This module
+should be considered private and should not be imported directly by users.
+There are no guarantees that this module will exist in the future.
+
+"""
+
+import uuid
+from weakref import WeakValueDictionary
+from threading import Lock
+
+
+class SerializableLock:
+    """A Serializable per-process Lock.
+
+    This wraps a normal ``threading.Lock`` object and satisfies the same
+    interface.  However, this lock can also be serialized and sent to different
+    processes.  It will not block concurrent operations between processes (for
+    this you should look at ``multiprocessing.Lock`` or ``locket.lock_file``
+    but will consistently deserialize into the same lock.
+
+    So if we make a lock in one process::
+
+        lock = SerializableLock()
+
+    And then send it over to another process multiple times::
+
+        bytes = pickle.dumps(lock)
+        a = pickle.loads(bytes)
+        b = pickle.loads(bytes)
+
+    Then the deserialized objects will operate as though they were the same
+    lock, and collide as appropriate.
+
+    This is useful for consistently protecting resources on a per-process
+    level.
+
+    The creation of locks is itself not threadsafe.
+    """
+
+    _locks = WeakValueDictionary()
+
+    def __init__(self, token=None):
+        self.token = token or str(uuid.uuid4())
+        if self.token in SerializableLock._locks:
+            self.lock = SerializableLock._locks[self.token]
+        else:
+            self.lock = Lock()
+            SerializableLock._locks[self.token] = self.lock
+
+    def acquire(self, *args, **kwargs):
+        return self.lock.acquire(*args, **kwargs)
+
+    def release(self, *args, **kwargs):
+        return self.lock.release(*args, **kwargs)
+
+    def __enter__(self):
+        self.lock.__enter__()
+
+    def __exit__(self, *args):
+        self.lock.__exit__(*args)
+
+    def locked(self):
+        return self.lock.locked()
+
+    def __getstate__(self):
+        return self.token
+
+    def __setstate__(self, token):
+        self.__init__(token)
+
+    def __str__(self):
+        return f"<{self.__class__.__name__}: {self.token}>"
+
+    __repr__ = __str__

--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -25,10 +25,11 @@ import ast
 import os
 import site
 import sys
-import threading
 import pprint
 from copy import deepcopy
 from collections.abc import Mapping
+
+from ._lock import SerializableLock
 
 try:
     from contextlib import nullcontext
@@ -368,7 +369,7 @@ class Config(object):
         self.paths = paths
         self.defaults = defaults or []
         self.config = {}
-        self.config_lock = threading.Lock()
+        self.config_lock = SerializableLock()
         self.refresh()
 
     def __contains__(self, item):

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -36,6 +36,7 @@ from donfig.config_obj import (Config, update, merge, collect_yaml,
 from donfig.utils import tmpfile
 from collections import OrderedDict
 from contextlib import contextmanager
+import cloudpickle
 
 CONFIG_NAME = 'mytest'
 ENV_PREFIX = CONFIG_NAME.upper() + '_'
@@ -535,3 +536,10 @@ def test__get_paths(monkeypatch):
         paths = config.paths
         assert os.path.join(prefix, "etc", "mypkg") in paths
         assert len(paths) == len(set(paths))
+
+
+def test_serialization():
+    config = Config(CONFIG_NAME)
+    config.set(one_key="one_value")
+    new_config = cloudpickle.loads(cloudpickle.dumps(config))
+    assert new_config.get("one_key") == "one_value"

--- a/donfig/tests/test_lock.py
+++ b/donfig/tests/test_lock.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Donfig Developers
+# Copyright (c) 2014-2018, Anaconda, Inc. and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pickle
+
+from .._lock import SerializableLock
+
+
+def test_SerializableLock():
+    a = SerializableLock()
+    b = SerializableLock()
+    with a:
+        pass
+
+    with a:
+        with b:
+            pass
+
+    with a:
+        assert not a.acquire(False)
+
+    a2 = pickle.loads(pickle.dumps(a))
+    a3 = pickle.loads(pickle.dumps(a))
+    a4 = pickle.loads(pickle.dumps(a2))
+
+    for x in [a, a2, a3, a4]:
+        for y in [a, a2, a3, a4]:
+            with x:
+                assert not y.acquire(False)
+
+    b2 = pickle.loads(pickle.dumps(b))
+    b3 = pickle.loads(pickle.dumps(b2))
+
+    for x in [a, a2, a3, a4]:
+        for y in [b, b2, b3]:
+            with x:
+                with y:
+                    pass
+            with y:
+                with x:
+                    pass
+
+
+def test_SerializableLock_name_collision():
+    a = SerializableLock("a")
+    b = SerializableLock("b")
+    c = SerializableLock("a")
+    d = SerializableLock()
+
+    assert a.lock is not b.lock
+    assert a.lock is c.lock
+    assert d.lock not in (a.lock, b.lock, c.lock)
+
+
+def test_SerializableLock_locked():
+    a = SerializableLock("a")
+    assert not a.locked()
+    with a:
+        assert a.locked()
+    assert not a.locked()
+
+
+def test_SerializableLock_acquire_blocking():
+    a = SerializableLock("a")
+    assert a.acquire(blocking=True)
+    assert not a.acquire(blocking=False)
+    a.release()

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name=NAME,
       packages=find_packages(),
       zip_safe=False,
       install_requires=['pyyaml'],
-      tests_require=['pytest'],
+      tests_require=['pytest', 'cloudpickle'],
       python_requires='>=3.6',
       )


### PR DESCRIPTION
Closes #17.

This is somewhere between a bug fix and an enhancement. This is a bug fix for a feature that was never advertised :wink:. That feature is being able to serialize the Config object. To accomplish this the `SerializableLock` class has been copied over from Dask.