### PR TITLE
Add configuration serialization and deserialization

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -195,6 +195,6 @@ epub_exclude_files = ["search.html"]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3/", None),
     "dask": ("https://dask.pydata.org/en/latest", None),
 }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -204,6 +204,22 @@ Note that the ``set`` function treats underscores and hyphens identically.
 For example, ``mypkg.config.set({'scheduler.work-stealing': True})`` is
 equivalent to ``mypkg.config.set({'scheduler.work_stealing': True})``.
 
+Distributing configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It may also be desirable to package up your whole configuration for use on
+another machine. This is used in some libraries (ex. Dask Distributed) to
+ensure remote components have the same configuration as your local system.
+
+This is typically handled by the downstream libraries which use base64
+encoding to pass config via the ``MYPKG_INTERNAL_INHERIT_CONFIG`` environment
+variable.
+
+.. autosummary::
+   donfig.serialize
+   donfig.deserialize
+   donfig.Config.serialize
+
 Conversion Utility
 ~~~~~~~~~~~~~~~~~~
 

--- a/donfig/__init__.py
+++ b/donfig/__init__.py
@@ -1,4 +1,4 @@
 from . import version  # noqa
-from .config_obj import Config  # noqa
+from .config_obj import Config, deserialize, serialize  # noqa
 
 __version__ = version.get_versions()["version"]


### PR DESCRIPTION
This is a port of the work done in https://github.com/dask/dask/pull/6987

It adds a `serialize` and `deserialize` function to make it easier to send a config to a remote machine as an environment variable. I also added a convenience `Config.serialize` which serializes the current Config object.

CC @jhamman who might be interested in this since we've talked about serialization in the past.
Also CC @jacobtomlinson in case he has any opinions.