### PR TITLE
No namespaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
 include-package-data = true
 
 [tool.setuptools.packages]
-find = {}
+find = { namespaces = false }
 
 [tool.mypy]
 # Silence errors about Python 3.9-style delayed type annotations on Python 3.8


### PR DESCRIPTION
Disable setuptools implicit namespaces to avoid that `doc/config.py` is installed together with the `donfig` package.