### PR TITLE
fix: Config.merge always raised AttributeError

### DIFF
--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -594,7 +594,7 @@ class Config:
         See :func:`~donfig.config_obj.merge` for more information.
 
         """
-        self.config = merge(self.config, dicts)
+        self.config = merge(self.config, *dicts)
 
     def update(self, new, priority="new"):
         """Update the internal configuration dictionary with `new`.

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -96,6 +96,14 @@ def test_merge():
     assert c == expected
 
 
+def test_config_merge():
+    config = Config(CONFIG_NAME)
+    config.clear()
+    config.update({"x": 1, "y": {"a": 1}})
+    config.merge({"y": {"b": 2}}, {"z": 3})
+    assert config.to_dict() == {"x": 1, "y": {"a": 1, "b": 2}, "z": 3}
+
+
 def test_collect_yaml_paths():
     a = {"x": 1, "y": {"a": 1}}
     b = {"x": 2, "z": 3, "y": {"b": 2}}


### PR DESCRIPTION
This change fixes `config.merge()`, which previously always raised `AttributeError: 'tuple' object has no attribute 'items'`.