### PR TITLE
fix: copy caller-supplied defaults instead of aliasing

### DIFF
--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -398,7 +398,7 @@ class Config:
     def __init__(
         self,
         name: str,
-        defaults: list[Mapping[str, Any]] | None = None,
+        defaults: Sequence[Mapping[str, Any]] | None = None,
         paths: list[str] | None = None,
         env: Mapping[str, str] | None = None,
         env_var: str | None = None,
@@ -438,7 +438,7 @@ class Config:
         self.env = env
         self.main_path = main_path
         self.paths = paths
-        self.defaults = defaults or []
+        self.defaults: list[Mapping[str, Any]] = list(defaults) if defaults is not None else []
         self.deprecations = deprecations
 
         self.config: MutableMapping[str, Any] = {}

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -78,12 +78,24 @@ def test_update_defaults():
     new = {"a": 0, "b": {"c": 0, "d": 0}, "new-extra": 0}
     config.update_defaults(new)
 
-    assert defaults == [
+    assert config.defaults == [
         {"a": 1, "b": {"c": 1}},
         {"a": 2, "b": {"d": 2}},
         {"a": 0, "b": {"c": 0, "d": 0}, "new-extra": 0},
     ]
+    # the caller's list is copied on init, not aliased
+    assert defaults == [
+        {"a": 1, "b": {"c": 1}},
+        {"a": 2, "b": {"d": 2}},
+    ]
     assert config.to_dict() == {"a": 0, "b": {"c": 0, "d": 3}, "extra": 0, "new-extra": 0}
+
+
+def test_defaults_accepts_any_sequence():
+    config = Config(CONFIG_NAME, defaults=({"a": 1}, {"b": 2}))
+    assert config.to_dict() == {"a": 1, "b": 2}
+    config.update_defaults({"c": 3})
+    assert config.get("c") == 3
 
 
 def test_merge():


### PR DESCRIPTION
This PR isolates the bug fix that @djhoese recommended in https://github.com/pytroll/donfig/pull/149#discussion_r3658329314 into a distinct PR. I assumed the test that aliased the callers argument was correct; in fact that was a bug in both the code and tests. This PR makes sure that the caller supplied defaults are always copied.