### PR TITLE
fix: copy caller-supplied paths instead of aliasing

### DIFF
--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -399,7 +399,7 @@ class Config:
         self,
         name: str,
         defaults: Sequence[Mapping[str, Any]] | None = None,
-        paths: Sequence[str] | None = None,
+        paths: list[str] | None = None,
         env: Mapping[str, str] | None = None,
         env_var: str | None = None,
         root_env_var: str | None = None,
@@ -417,8 +417,6 @@ class Config:
             ]
         else:
             # copy so the env-var append below never mutates the caller's sequence
-            if isinstance(paths, str):
-                raise TypeError("paths must be a sequence of strings, not a single string")
             paths = list(paths)
         if env_prefix is None:
             env_prefix = f"{name.upper()}_"
@@ -462,7 +460,7 @@ class Config:
     def pprint(self, **kwargs):
         return pprint.pprint(self.config, **kwargs)
 
-    def collect(self, paths: Sequence[str] | None = None, env: Mapping[str, str] | None = None) -> dict:
+    def collect(self, paths: list[str] | None = None, env: Mapping[str, str] | None = None) -> dict:
         """Collect configuration from paths and environment variables
 
         Parameters

--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -416,7 +416,7 @@ class Config:
                 os.path.join(os.path.expanduser("~"), ".config", name),
             ]
         else:
-            # copy so the env-var append below never mutates the caller's sequence
+            # copy so the env-var append below never mutates the caller's list
             paths = list(paths)
         if env_prefix is None:
             env_prefix = f"{name.upper()}_"

--- a/donfig/config_obj.py
+++ b/donfig/config_obj.py
@@ -399,7 +399,7 @@ class Config:
         self,
         name: str,
         defaults: Sequence[Mapping[str, Any]] | None = None,
-        paths: list[str] | None = None,
+        paths: Sequence[str] | None = None,
         env: Mapping[str, str] | None = None,
         env_var: str | None = None,
         root_env_var: str | None = None,
@@ -415,7 +415,11 @@ class Config:
                 *[os.path.join(prefix, "etc", name) for prefix in site.PREFIXES],
                 os.path.join(os.path.expanduser("~"), ".config", name),
             ]
-
+        else:
+            # copy so the env-var append below never mutates the caller's sequence
+            if isinstance(paths, str):
+                raise TypeError("paths must be a sequence of strings, not a single string")
+            paths = list(paths)
         if env_prefix is None:
             env_prefix = f"{name.upper()}_"
         if env is None:
@@ -458,7 +462,7 @@ class Config:
     def pprint(self, **kwargs):
         return pprint.pprint(self.config, **kwargs)
 
-    def collect(self, paths: list[str] | None = None, env: Mapping[str, str] | None = None) -> dict:
+    def collect(self, paths: Sequence[str] | None = None, env: Mapping[str, str] | None = None) -> dict:
         """Collect configuration from paths and environment variables
 
         Parameters

--- a/donfig/tests/test_config.py
+++ b/donfig/tests/test_config.py
@@ -606,6 +606,21 @@ def test__get_paths(monkeypatch):
         assert len(paths) == len(set(paths))
 
 
+def test_paths_not_mutated(monkeypatch):
+    monkeypatch.setenv("MYPKG_CONFIG", "foo-bar")
+    paths = ["/etc/mypkg"]
+    config = Config("mypkg", paths=paths)
+    assert config.paths == ["/etc/mypkg", "foo-bar"]
+    # the caller's list is copied on init, not aliased
+    assert paths == ["/etc/mypkg"]
+
+
+def test_paths_accepts_any_sequence(monkeypatch):
+    monkeypatch.setenv("MYPKG_CONFIG", "foo-bar")
+    config = Config("mypkg", paths=("/etc/mypkg",))
+    assert config.paths == ["/etc/mypkg", "foo-bar"]
+
+
 def test_serialization():
     config = Config(CONFIG_NAME)
     config.set(one_key="one_value")


### PR DESCRIPTION
This PR fixes an accidental mutation bug similar to #150, under the assumption this behavior isn't intended.